### PR TITLE
Kibana startup fix

### DIFF
--- a/templates/kibana.yml.j2
+++ b/templates/kibana.yml.j2
@@ -25,7 +25,9 @@ server.host: "{{ kibana_server_host }}"
 #server.name: "your-hostname"
 
 # The URL of the Elasticsearch instance to use for all your queries.
-elasticsearch.url: {{ kibana_elasticsearch_url }}
+# 'elasticsearch.url' has been deprecated in favor of 'elasticsearch.hosts'
+#elasticsearch.url: {{ kibana_elasticsearch_url }}
+elasticsearch.hosts: {{ kibana_elasticsearch_url }}
 
 # When this setting's value is true Kibana uses the hostname specified in the server.host
 # setting. When the value of this setting is false, Kibana uses the hostname of the host

--- a/templates/kibana.yml.j2
+++ b/templates/kibana.yml.j2
@@ -24,9 +24,8 @@ server.host: "{{ kibana_server_host }}"
 # The Kibana server's name.  This is used for display purposes.
 #server.name: "your-hostname"
 
-# The URL of the Elasticsearch instance to use for all your queries.
-# 'elasticsearch.url' has been deprecated in favor of 'elasticsearch.hosts'
-#elasticsearch.url: {{ kibana_elasticsearch_url }}
+# The Hosts of the Elasticsearch instance to use for all your queries.
+# default: http://localhost:9200
 elasticsearch.hosts: {{ kibana_elasticsearch_url }}
 
 # When this setting's value is true Kibana uses the hostname specified in the server.host


### PR DESCRIPTION
kibana would refuse to start, unable to find elasticsearch, until elasticsearch.url was changed out for elasticsearch.hosts (https://github.com/elastic/kibana/issues/40335#issuecomment-544488698)